### PR TITLE
Check for multiprocessing_on_dill

### DIFF
--- a/identifiability.py
+++ b/identifiability.py
@@ -14,7 +14,12 @@ import numpy as np
 import scipy as sp
 import math
 from matplotlib import pyplot as plt
-from multiprocessing import Pool
+try:
+    from multiprocessing_on_dill import Pool
+    print("module 'multiprocessing_on_dill' is installed")
+except ModuleNotFoundError:
+    print("module 'multiprocessing_on_dill' is not installed")
+    from multiprocessing import Pool
 
 __version__ = '0.3.3dev1'
 


### PR DESCRIPTION
Added check to import pool from multiprocessing_on_dill instead of from multiprocessing. This allows for serialization of nested functions which is needed for some applications of multiprocessing.